### PR TITLE
Fix push status port

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Update all .example files and/or folders to match your needs. This step is not r
 * `--grafanaDomain`: Overwrite grafana.ini domain
 * `--grafanaPort`: port for Grafana to run on
 * `--relayPort`: port for relay-ng to run on (default: 2003)
-* `--pushStatusPort`: port for the stats-getter push API (default: disabled)
+* `--pushStatusPort`: port for the stats-getter push API (default: false)
+  true will set it to 10004, otherwise specify a port number it'll listen to
 
 #### Exporting
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -34,6 +34,16 @@ const logger = createLogger({
 async function main() {
   argv.grafanaPort = argv.grafanaPort ?? await getPort({ portRange: [3000, 4000] });
   argv.serverPort = argv.serverPort ?? 21025;
+  if (argv.pushStatusPort === true) {
+    argv.pushStatusPort = 10004;
+  } else {
+    const port = Number(argv.pushStatusPort);
+    if (!Number.isNaN(port)) {
+      argv.pushStatusPort = port;
+    } else {
+      delete argv.pushStatusPort;
+    }
+  }
 
   const cli = {
     cmd: argv._.shift(),

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -49,7 +49,7 @@ services:
     environment:
       - PREFIX=
       - SERVER_PORT=21025
-      - INCLUDE_PUSH_STATUS_API=false
+      - PUSH_STATUS_PORT=
     networks:
       - stats
     logging: *default-logging

--- a/src/pushStats/index.js
+++ b/src/pushStats/index.js
@@ -12,7 +12,7 @@ import express from 'express';
 import ApiFunc from './apiFunctions.js';
 
 const app = express();
-const port = 10004;
+const pushStatusPort = Number(process.env.PUSH_STATUS_PORT);
 let lastUpload = new Date().getTime();
 
 const users = JSON.parse(fs.readFileSync('users.json'));
@@ -233,9 +233,9 @@ cron.schedule('*/30 * * * * *', async () => {
   });
 });
 
-if (process.env.INCLUDE_PUSH_STATUS_API === 'true') {
-  app.listen(port, () => {
-    console.log(`App listening at http://localhost:${port}`);
+if (pushStatusPort) {
+  app.listen(pushStatusPort, () => {
+    console.log(`App listening at http://localhost:${pushStatusPort}`);
   });
   app.get('/', (req, res) => {
     const diffCompleteMinutes = Math.ceil(

--- a/src/setup/setup.js
+++ b/src/setup/setup.js
@@ -57,8 +57,8 @@ async function UpdateDockerComposeFile() {
   }
   if (argv.pushStatusPort) {
     contents = contents.replace(
-      'INCLUDE_PUSH_STATUS_API=false',
-      `INCLUDE_PUSH_STATUS_API=true${regexEscape}    ports:${regexEscape}        - ${argv.pushStatusPort}:${argv.pushStatusPort}`,
+      'PUSH_STATUS_PORT=',
+      `PUSH_STATUS_PORT=${argv.pushStatusPort}${regexEscape}    ports:${regexEscape}        - ${argv.pushStatusPort}:${argv.pushStatusPort}`,
     );
   }
   if (argv.prefix) {


### PR DESCRIPTION
I missed the port being hardcoded in the stat-pusher.

This makes it properly go through the environment. The setup harness will auto-use 10004 if --pushStatusPort is set, otherwise set it to the specified value.