### PR TITLE
Make the users.json file permanent

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 
 ## Setup
 
-1. Update all .example files and/or folders to match your needs. This step is not required if you are using the default setup.
+1. Edit `example.env` and `docker-compose.example.yml` to match your needs. This step is not required if you are using the default setup.
+2. Copy `users.example.json` to `users.json` and edit it according to [User Setup](#User-Setup).
 2. Add your own Grafana variables in `grafanaConfig/.env.grafana`. This file will be updated after a volume reset.
 
 ### User Setup

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -44,6 +44,7 @@ services:
       dockerfile: ./src/pushStats/Dockerfile
     volumes:
       - ./logs/statsGetter:/app/logs
+      - ./users.json:/app/users.json
     depends_on:
       - graphite
     environment:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "setup": "node bin/server.js setup",
     "start": "node bin/server.js start --grafanaPort=3000",
     "start:test": "node bin/server.js start --grafanaPort=3000 --force",
+    "rebuild": "docker compose build --no-cache",
     "lint": "eslint src/**/*.js && eslint dashboards/**/*.js",
     "lint:fix": "eslint src/**/*.js --fix && eslint dashboards/**/*.js --fix",
     "update-stats-getter": "docker-compose up --detach --build"

--- a/src/pushStats/Dockerfile
+++ b/src/pushStats/Dockerfile
@@ -6,7 +6,6 @@ ENV NODE_ENV=production
 
 COPY ./src/pushStats .
 
-COPY ./users.json ./users.json
-RUN npm install
+RUN npm clean-install
 
 CMD ["node", "index.js"]

--- a/src/setup/setup.js
+++ b/src/setup/setup.js
@@ -69,18 +69,6 @@ async function UpdateDockerComposeFile() {
   logger.info('Docker-compose file created');
 }
 
-function UpdateUsersFile() {
-  const usersFile = join(__dirname, '../../users.json');
-  if (fs.existsSync(usersFile) && !argv.force) {
-    return logger.warn('Users file already exists, use --force to overwrite it');
-  }
-
-  const exampleUsersFilePath = join(__dirname, '../../users.example.json');
-  const exampleUsersText = fs.readFileSync(exampleUsersFilePath, 'utf8');
-  fs.writeFileSync(usersFile, exampleUsersText);
-  logger.info('Users file created');
-}
-
 function UpdateGrafanaConfigFolder() {
   const configDirPath = join(__dirname, '../../grafanaConfig');
   if (fs.existsSync(configDirPath) && !argv.force) {
@@ -148,7 +136,12 @@ async function Setup(cli) {
   argv = cli.args;
   logger = cli.logger;
 
-  UpdateUsersFile();
+  const usersFile = join(__dirname, '../../users.json');
+  if (!fs.existsSync(usersFile)) {
+    logger.error('missing users.json file');
+    process.exit(-1);
+  }
+
   UpdateEnvFile();
   await UpdateDockerComposeFile();
   UpdateGrafanaConfigFolder();
@@ -161,7 +154,6 @@ module.exports.commands = async function Commands(grafanaApiUrl) {
 
   const commands = [
     { command: `docker compose down ${argv.removeVolumes ? '--volumes' : ''} --remove-orphans`, name: 'docker-compose down' },
-    { command: 'docker compose build --no-cache', name: 'docker-compose build' },
     { command: 'docker compose up -d', name: 'docker-compose up' },
   ];
 


### PR DESCRIPTION
Instead of having the setup potentially copy over the example user file, just ask the user to set it up himself. This stops mistakes from happening with `--force`.

Also mount the file into the container instead of copying it, so that an update just needs a container restart and not a rebuild. Hence, remove the rebuilding from the start script and add it as a developer-intended command to the npm scripts (since the only reason to rebuild would be if the pushStats scripts is edited).